### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To get started:
     npm run serve
 
     # Using Yarn
-    yarn run serve
+    yarn serve
     ```
 
     Now you should be able to see the project running at localhost:8080.


### PR DESCRIPTION
```yarn serve``` also works, it does not have to be ```yarn run serve```, not sure since what version.